### PR TITLE
Plugin Update for SonoranCAD v3.0 Release

### DIFF
--- a/lookups/sv_lookups.lua
+++ b/lookups/sv_lookups.lua
@@ -132,6 +132,64 @@ if pluginConfig.enabled then
             data["apiId"] = autoLookup
         end
         cadLookup(data, callback, autoLookup)
+        
+    end
+
+    function cadGetInformation(plate, callback, autoLookup)
+        local data = {}
+        data["plate"] = plate
+        if autoLookup ~= nil then
+            data["apiId"] = autoLookup
+        end
+        cadLookup(data, function(result)
+            local regData = {}
+            local charData = {}
+            local vehData = {}
+            local boloData = {}
+            for _, record in pairs(result.records) do
+                if record.type == 5 then
+                    for _, section in pairs(record.sections) do
+                        if section.category == 0 then
+                            local reg = {}
+                            for _, field in pairs(section.fields) do
+                                reg[field.label] = field.value
+                            end
+                            table.insert(regData, reg)
+                        elseif section.category == 3 then
+                            for _, field in pairs(section.fields) do
+                                if field["data"] ~= nil then
+                                    if field.data["first"] ~= nil then
+                                        table.insert(charData, field.data)
+                                    end
+                                end
+                            end
+                        elseif section.category == 4 then
+                            for _, field in pairs(section.fields) do
+                                
+                                if field["data"] ~= nil then
+                                    if field.data["plate"] ~= nil then
+                                        table.insert(vehData, field.data)
+                                    end
+                                end
+                            end
+                        end
+                    end
+                elseif record.type == 3 then
+                    for _, section in pairs(record.sections) do
+                        if section.category == 1 then-- flags
+                            for _, field in pairs(section.fields) do
+                                if field["data"] ~= nil then
+                                    if field["data"]["flags"] ~= nil then
+                                        boloData = field["data"]["flags"]
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+            callback(regData, vehData, charData, boloData)
+        end, autoLookup)
     end
 
     exports('cadNameLookup', cadNameLookup)

--- a/lookups/sv_lookups.lua
+++ b/lookups/sv_lookups.lua
@@ -178,9 +178,11 @@ if pluginConfig.enabled then
                     for _, section in pairs(record.sections) do
                         if section.category == 1 then-- flags
                             for _, field in pairs(section.fields) do
-                                if field["data"] ~= nil then
+                                if field["data"] ~= nil then -- is a BOLO, might not have flags
                                     if field["data"]["flags"] ~= nil then
                                         boloData = field["data"]["flags"]
+                                    else
+                                        boloData = {"BOLO"}
                                     end
                                 end
                             end

--- a/lookups/sv_lookups.lua
+++ b/lookups/sv_lookups.lua
@@ -10,44 +10,98 @@ local pluginConfig = Config.GetPluginConfig("lookups")
 
 if pluginConfig.enabled then
 
-    registerApiType("LOOKUP_PLATE", "emergency")
-    registerApiType("LOOKUP_NAME", "emergency")
+    registerApiType("LOOKUP", "general")
 
-    local PlateCache = {}
+    local LookupCache = {}
 
-    local Plate = {
-        plateNumber = nil,
-        lastFetched = nil,
-        regInfo = nil
+    local Lookup = {
+        first = nil,
+        last = nil,
+        mi = nil,
+        plate = nil,
+        types = nil,
+        lastFetched = nil
     }
-    function Plate.Create(plateNumber, regInfo)
-        local self = shallowcopy(Plate)
-        self.plateNumber = plateNumber
-        self.regInfo = {["vehicleRegistrations"] = regInfo}
+    function Lookup.Create(first, last, mi, plate, types, response)
+        local self = shallowcopy(Lookup)
+        self.first = first
+        self.last = last
+        self.mi = mi
+        self.plate = plate
+        self.types = types
         self.lastFetched = GetGameTimer()
+        self.response = response
         return self
     end
-
-    function Plate:UpdateCache(regInfo)
-        self.regInfo = regInfo
+    function Lookup:UpdateCache()
+        self.response = info
         self.lastFetched = GetGameTimer()
     end
-
-
-    -- Stale plate garbage collector
-    local function PurgeStalePlates()
-        local currentTime = GetGameTimer()
-        for k, v in pairs(PlateCache) do
-            local garbageTime = v.lastFetched + (pluginConfig.maxCacheTime*1000)
-            if currentTime >= garbageTime then
-                PlateCache[k] = nil
-                debugPrint(("Stale plate purged %s"):format(k))
+    function Lookup:IsMatch(first, last, mi, plate, types)
+        if self.first == first and self.last == last and self.mi == mi and self.plate == plate then
+            for _, v in pairs(self.types) do
+                local match = false
+                for __, v2 in pairs(types) do
+                    if v2 == v then
+                        match = true
+                    end
+                end
+                if not match then
+                    return false
+                end
             end
+            return true
+        else
+            return false
         end
-        SetTimeout(pluginConfig.stalePurgeTimer*1000, PurgeStalePlates)
     end
 
-    PurgeStalePlates()
+    -- Stale lookup garbage collector
+    local function PurgeStaleLookups()
+        local currentTime = GetGameTimer()
+        for k, v in pairs(LookupCache) do
+            local garbageTime = v.lastFetched + (pluginConfig.maxCacheTime*1000)
+            if currentTime >= garbageTime then
+                LookupCache[k] = nil
+                debugPrint(("Stale lookup purged %s"):format(k))
+            end
+        end
+        SetTimeout(pluginConfig.stalePurgeTimer*1000, PurgeStaleLookups)
+    end
+
+    PurgeStaleLookups()
+
+    function cadLookup(data, callback, autoLookup)
+        -- check if the lookupData has all required fields
+        data["first"] = data["first"] == nil and "" or data["first"]
+        data["mi"] = data["mi"] == nil and "" or data["mi"]
+        data["last"] = data["last"] == nil and "" or data["last"]
+        data["plate"] = data["plate"] == nil and "" or data["plate"]:match("^%s*(.-)%s*$")
+        data["types"] = data["types"] == nil and {2,3,4,5} or data["types"]
+        if autoLookup ~= nil then
+            data["apiId"] = autoLookup
+        end
+        -- check cache
+        for k, v in pairs(LookupCache) do
+            if v:IsMatch(data.first, data.last, data.mi, data.plate, data.types) then
+                debugLog("Returning cached response")
+                callback(json.decode(v.response))
+                return
+            end
+        end
+        performApiRequest({data}, "LOOKUP", function(result)
+            debugLog("Performed lookup")
+            local lookup = json.decode(result)
+            local l = Lookup.Create(data.first, data.last, data.mi, data.plate, data.types, result)
+            table.insert(LookupCache, l)
+            callback(lookup)
+        end)
+            
+    end
+
+    function cadLookupInt(searchType, value, types, callback, autoLookup)
+
+    end
 
     --[[
         cadNameLookup
@@ -58,57 +112,26 @@ if pluginConfig.enabled then
     ]]
     function cadNameLookup(first, last, mi, callback)
         local data = {}
-        data["first"] = first ~= nil and first or ""
-        data["last"] = last ~= nil and last or ""
-        data["mi"] = mi ~= nil and mi or ""
-        
-        performApiRequest({data}, "LOOKUP_NAME", function(result)
-            debugPrint("name lookup: "..tostring(result))
-            local lookup = json.decode(result)
-            callback(lookup)
-        end)
+        data.first = first
+        data.last = last
+        data.mi = mi
+        cadLookup(data, callback, autoLookup)
     end
 
     --[[
         cadPlateLookup
             plate: plate number
-            basicFlag: true returns cached record if possible which only contains vehicleRegistrations object, false calls the API
+            basicFlag: deprecated
             callback: the function called with the return data
             autoLookup: when populated with an API ID, pops open a search window on the officer's CAD (optional)
     ]]
     function cadPlateLookup(plate, basicFlag, callback, autoLookup)
         local data = {}
-        data["plate"] = plate:match("^%s*(.-)%s*$")
+        data["plate"] = plate
         if autoLookup ~= nil then
             data["apiId"] = autoLookup
         end
-        if PlateCache[data["plate"]] ~= nil and basicFlag then
-            local currentTime = GetGameTimer()
-            local expireTime = PlateCache[data["plate"]].lastFetched + (pluginConfig.maxCacheTime * 1000)
-            if currentTime <= expireTime then
-                -- cache hit
-                callback(PlateCache[data["plate"]].regInfo) 
-            else
-                -- cache miss
-                debugPrint(("Plate %s out of date, fetching."):format(data["plate"]))
-                performApiRequest({data}, "LOOKUP_PLATE", function(result)
-                    debugPrint("plate lookup: "..tostring(result))
-                    local lookup = json.decode(result)
-                    PlateCache[data["plate"]]:UpdateCache(lookup["vehicleRegistrations"])
-                    callback(lookup)
-                end)
-            end
-        else
-            -- not cached
-            debugPrint(("Plate %s not cached or basicFlag not set, fetching."):format(data["plate"]))
-            performApiRequest({data}, "LOOKUP_PLATE", function(result)
-                debugPrint("plate lookup: "..tostring(result))
-                local lookup = json.decode(result)
-                local plate = Plate.Create(data["plate"], lookup["vehicleRegistrations"])
-                PlateCache[data["plate"]] = plate
-                callback(lookup)
-            end)
-        end
+        cadLookup(data, callback, autoLookup)
     end
 
     exports('cadNameLookup', cadNameLookup)

--- a/lookups/version_lookups.json
+++ b/lookups/version_lookups.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3",
+    "version": "1.4",
     "check_url": "https://raw.githubusercontent.com/Sonoran-Software/sonoran_lookups/master/lookups/version_lookups.json",
     "download_url": "https://github.com/Sonoran-Software/sonoran_lookups/"
 }


### PR DESCRIPTION
Version 3.0 changes the lookup API, so we need to update this plugin to use the new format. Allows plugins to look up data based on a filterable search and returns most data.

Does not currently support custom records or reports. The lookups plugin is mostly used by the wraithv2 plugin which does not require this data.