### PR TITLE
Fix hard coded "flags" section label & add "boloStatusUid" config option

### DIFF
--- a/lookups/CHANGEMEconfig_lookups.lua
+++ b/lookups/CHANGEMEconfig_lookups.lua
@@ -12,7 +12,7 @@ local config = {
     -- put your configuration options below
     maxCacheTime = 120, -- max time to cache a plate hit, in seconds
     stalePurgeTimer = 600, -- delay between garbage collection, default 10 minutes
-    autoLookupEnabled = true
+    boloStatusUid = "status" -- field mapping id / uid for the Bolo Custom Record status field, this is to determine if a bolo is active or not
 }
 
 if config.enabled then

--- a/lookups/CHANGEMEconfig_lookups.lua
+++ b/lookups/CHANGEMEconfig_lookups.lua
@@ -5,6 +5,7 @@
 ]]
 local config = {
     enabled = false,
+    configVersion = "2.0",
     pluginName = "lookups", -- name your plugin here
     pluginAuthor = "SonoranCAD", -- author
     requiresPlugins = {}, -- required plugins for this plugin to work, separated by commas

--- a/lookups/sv_lookups.lua
+++ b/lookups/sv_lookups.lua
@@ -148,6 +148,7 @@ if pluginConfig.enabled then
         if autoLookup ~= nil then
             data["apiId"] = autoLookup
         end
+        local boloStatusUid = pluginConfig.boloStatusUid ~= nil and pluginConfig.boloStatusUid or "status"
         cadLookup(data, function(result)
             local regData = {}
             local charData = {}
@@ -208,7 +209,7 @@ if pluginConfig.enabled then
                             local boloActive = true
                             for _, section in pairs(v.sections) do
                                 for _, field in pairs(section.fields) do
-                                    if field.uid == "status" then
+                                    if field.uid == boloStatusUid then
                                         debugLog(("Found BOLO status field %s with value %s"):format(field.label, field.value))
                                         if field.value == "0" then
                                             boloActive = true
@@ -217,7 +218,7 @@ if pluginConfig.enabled then
                                         end
                                     end
                                 end
-                                if section.category == 1 and section.label == "Flags" then-- flags
+                                if section.category == 1
                                     if section.fields.data ~= nil and section.fields.data.flags ~= nil then
                                         boloData = section.fields.data.flags
                                     else

--- a/lookups/sv_lookups.lua
+++ b/lookups/sv_lookups.lua
@@ -218,7 +218,7 @@ if pluginConfig.enabled then
                                         end
                                     end
                                 end
-                                if section.category == 1
+                                if section.category == 1 then
                                     if section.fields.data ~= nil and section.fields.data.flags ~= nil then
                                         boloData = section.fields.data.flags
                                     else

--- a/lookups/version_lookups.json
+++ b/lookups/version_lookups.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.1",
+    "version": "1.5.2",
     "check_url": "https://raw.githubusercontent.com/Sonoran-Software/sonoran_lookups/master/lookups/version_lookups.json",
     "download_url": "https://github.com/Sonoran-Software/sonoran_lookups/"
 }

--- a/lookups/version_lookups.json
+++ b/lookups/version_lookups.json
@@ -1,5 +1,6 @@
 {
     "version": "1.5.2",
+    "configVersion": "2.0",
     "check_url": "https://raw.githubusercontent.com/Sonoran-Software/sonoran_lookups/master/lookups/version_lookups.json",
     "download_url": "https://github.com/Sonoran-Software/sonoran_lookups/"
 }


### PR DESCRIPTION
On BOLO checking it checks the flags section, it checks it's category ID (1) and the label of the section, since the label of the section can be changed per community for translations, personal preference, etc. so it shouldn't be restricted to just "Flags" as the label.

Additionally adds config option to specify the bolo status uid as that can be different than just "status". This is in the lookup plugin instead of where it's used (wraithv2 plugin) as here it's evaluated if it's a valid BOLO or not.